### PR TITLE
Fixing configuration handling for the malware directory

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -112,6 +112,16 @@ var validateSessionSecret = function (config, testing) {
 };
 
 /**
+ * Validate configuration for vault
+ */
+var validateVaultConfig = function (config) {
+  var dir = config.vault.incomingDirectory;
+  if (dir.charAt(dir.length-1) !== '/') {
+    config.vault.incomingDirectory += '/';
+  }
+};
+
+/**
  * Initialize global configuration files
  */
 var initGlobalConfigFolders = function (config, assets) {
@@ -203,6 +213,9 @@ var initGlobalConfig = function () {
 
   // Validate session secret
   validateSessionSecret(config);
+
+  // Validating input for vault
+  validateVaultConfig(config);
 
   // Expose configuration utilities
   config.utils = {

--- a/config/config.js
+++ b/config/config.js
@@ -116,7 +116,7 @@ var validateSessionSecret = function (config, testing) {
  */
 var validateVaultConfig = function (config) {
   var dir = config.vault.incomingDirectory;
-  if (dir.charAt(dir.length-1) !== '/') {
+  if (dir.charAt(dir.length - 1) !== '/') {
     config.vault.incomingDirectory += '/';
   }
 };


### PR DESCRIPTION
Fixing vault configuration to include a validation of a trailing slash for directories
Fixes #11 
