### PR TITLE
Pass correct data structure to promise catch clause

### DIFF
--- a/config/lib/vault.js
+++ b/config/lib/vault.js
@@ -40,7 +40,7 @@ function vaultRun(vaultData, callback) {
     })
     .catch(function(data) {
       debug('vault: error completing flow: ' + data.local.msg);
-      return callback(data.local.msg, vaultData);
+      return callback(data.local.msg, data);
     });
 }
 


### PR DESCRIPTION
passing the correct data structure to the callback to make sure we're logging failed attempts too with their return status
Fixes #3 
